### PR TITLE
Add InsertEquivalentConvLayouts

### DIFF
--- a/lib/Transforms/InsertEquivalentConvLayouts/BUILD
+++ b/lib/Transforms/InsertEquivalentConvLayouts/BUILD
@@ -1,0 +1,33 @@
+load("@heir//lib/Transforms:transforms.bzl", "add_heir_transforms")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+package(
+    default_applicable_licenses = ["@heir//:license"],
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "InsertEquivalentConvLayouts",
+    srcs = ["InsertEquivalentConvLayouts.cpp"],
+    hdrs = ["InsertEquivalentConvLayouts.h"],
+    deps = [
+        ":pass_inc_gen",
+        "@heir//lib/Dialect/Secret/IR:Dialect",
+        "@heir//lib/Dialect/TensorExt/IR:Dialect",
+        "@heir//lib/Utils/Layout:ConvolutionLayoutBuilder",
+        "@heir//lib/Utils/Layout:Utils",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:Analysis",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:LinalgDialect",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Support",
+        "@tamagoyaki//:MLIREquivalence",
+    ],
+)
+
+add_heir_transforms(
+    generated_target_name = "pass_inc_gen",
+    pass_name = "InsertEquivalentConvLayouts",
+    td_file = "InsertEquivalentConvLayouts.td",
+)

--- a/lib/Transforms/InsertEquivalentConvLayouts/InsertEquivalentConvLayouts.cpp
+++ b/lib/Transforms/InsertEquivalentConvLayouts/InsertEquivalentConvLayouts.cpp
@@ -42,34 +42,39 @@ struct InsertEquivalentConvLayouts
     : impl::InsertEquivalentConvLayoutsBase<InsertEquivalentConvLayouts> {
   using InsertEquivalentConvLayoutsBase::InsertEquivalentConvLayoutsBase;
 
+  // Appends a candidate layout, skipping failures and duplicates.
+  void appendUnique(SmallVector<ConvolutionLayout>& configs,
+                    const FailureOr<ConvolutionLayout>& config) {
+    if (failed(config)) return;
+    bool duplicate = llvm::any_of(configs, [&](const ConvolutionLayout& e) {
+      return e.dataLayout == config->dataLayout &&
+             e.filterLayout == config->filterLayout &&
+             e.resultLayout == config->resultLayout;
+    });
+    if (!duplicate) configs.push_back(*config);
+  }
+
   // Candidate layouts for a multichannel conv: the MatvecDiagonal kernel with
-  // and without the pixel-shuffle row-interchange optimization. Identical
-  // candidates (e.g. when the stride is 1, the two coincide) are deduplicated.
+  // and without the pixel-shuffle row-interchange optimization (deduplicated,
+  // since for stride 1 the two coincide), plus the naive MatvecNaive packing.
   template <typename ConvOpTy>
   SmallVector<ConvolutionLayout> enumerateLayouts(ConvOpTy op) {
     SmallVector<ConvolutionLayout> configs;
-    for (bool interchangeRows : {false, true}) {
-      FailureOr<ConvolutionLayout> config = getMatvecDiagonalConvolutionLayout(
-          op, ciphertextSize, interchangeRows);
-      if (failed(config)) continue;
-      bool duplicate = llvm::any_of(configs, [&](const ConvolutionLayout& e) {
-        return e.dataLayout == config->dataLayout &&
-               e.filterLayout == config->filterLayout &&
-               e.resultLayout == config->resultLayout;
-      });
-      if (!duplicate) configs.push_back(*config);
-    }
+    for (bool interchangeRows : {false, true})
+      appendUnique(configs, getMatvecDiagonalConvolutionLayout(
+                                op, ciphertextSize, interchangeRows));
+    appendUnique(configs, getMatvecNaiveConvolutionLayout(op, ciphertextSize));
     return configs;
   }
 
-  // Candidate layouts for a single-channel conv: a single MatvecDiagonal
-  // packing (no row-interchange variant).
+  // Candidate layouts for a single-channel conv: the MatvecDiagonal packing (no
+  // row-interchange variant) plus the naive MatvecNaive packing.
   template <typename ConvOpTy>
   SmallVector<ConvolutionLayout> enumerateSingleChannelLayouts(ConvOpTy op) {
     SmallVector<ConvolutionLayout> configs;
-    FailureOr<ConvolutionLayout> config =
-        getMatvecDiagonalConvolutionLayout(op, ciphertextSize);
-    if (succeeded(config)) configs.push_back(*config);
+    appendUnique(configs,
+                 getMatvecDiagonalConvolutionLayout(op, ciphertextSize));
+    appendUnique(configs, getMatvecNaiveConvolutionLayout(op, ciphertextSize));
     return configs;
   }
 

--- a/lib/Transforms/InsertEquivalentConvLayouts/InsertEquivalentConvLayouts.cpp
+++ b/lib/Transforms/InsertEquivalentConvLayouts/InsertEquivalentConvLayouts.cpp
@@ -15,7 +15,8 @@
 #include "mlir/include/mlir/IR/MLIRContext.h"            // from @llvm-project
 #include "mlir/include/mlir/IR/Operation.h"              // from @llvm-project
 #include "mlir/include/mlir/IR/Value.h"                  // from @llvm-project
-#include "mlir/include/mlir/Support/LLVM.h"              // from @llvm-project
+#include "mlir/include/mlir/Interfaces/DestinationStyleOpInterface.h"  // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"  // from @llvm-project
 
 namespace mlir {
 namespace heir {
@@ -41,13 +42,49 @@ struct InsertEquivalentConvLayouts
     : impl::InsertEquivalentConvLayoutsBase<InsertEquivalentConvLayouts> {
   using InsertEquivalentConvLayoutsBase::InsertEquivalentConvLayoutsBase;
 
-  // Materializes every valid layout for `op` and groups the results in an
-  // equivalence.class. ConvOpTy is one of the multichannel linalg conv ops.
+  // Candidate layouts for a multichannel conv: the MatvecDiagonal kernel with
+  // and without the pixel-shuffle row-interchange optimization. Identical
+  // candidates (e.g. when the stride is 1, the two coincide) are deduplicated.
   template <typename ConvOpTy>
-  void processConv(ConvOpTy op) {
-    MLIRContext* ctx = op.getContext();
-    auto dataType = cast<RankedTensorType>(op.getInputs().front().getType());
-    auto filterType = cast<RankedTensorType>(op.getInputs().back().getType());
+  SmallVector<ConvolutionLayout> enumerateLayouts(ConvOpTy op) {
+    SmallVector<ConvolutionLayout> configs;
+    for (bool interchangeRows : {false, true}) {
+      FailureOr<ConvolutionLayout> config = getMatvecDiagonalConvolutionLayout(
+          op, ciphertextSize, interchangeRows);
+      if (failed(config)) continue;
+      bool duplicate = llvm::any_of(configs, [&](const ConvolutionLayout& e) {
+        return e.dataLayout == config->dataLayout &&
+               e.filterLayout == config->filterLayout &&
+               e.resultLayout == config->resultLayout;
+      });
+      if (!duplicate) configs.push_back(*config);
+    }
+    return configs;
+  }
+
+  // Candidate layouts for a single-channel conv: a single MatvecDiagonal
+  // packing (no row-interchange variant).
+  template <typename ConvOpTy>
+  SmallVector<ConvolutionLayout> enumerateSingleChannelLayouts(ConvOpTy op) {
+    SmallVector<ConvolutionLayout> configs;
+    FailureOr<ConvolutionLayout> config =
+        getMatvecDiagonalConvolutionLayout(op, ciphertextSize);
+    if (succeeded(config)) configs.push_back(*config);
+    return configs;
+  }
+
+  // Materializes each candidate layout for `op` and groups the results in an
+  // equivalence.class.
+  void buildEquivalenceClass(Operation* op,
+                             ArrayRef<ConvolutionLayout> configs) {
+    if (configs.empty()) return;
+
+    auto dpsOp = cast<DestinationStyleOpInterface>(op);
+    MLIRContext* ctx = op->getContext();
+    auto dataType =
+        cast<RankedTensorType>(dpsOp.getDpsInputOperand(0)->get().getType());
+    auto filterType =
+        cast<RankedTensorType>(dpsOp.getDpsInputOperand(1)->get().getType());
     auto outputType = cast<RankedTensorType>(op->getResult(0).getType());
 
     // A layout-free value is treated as living in the canonical row-major
@@ -56,15 +93,6 @@ struct InsertEquivalentConvLayouts
     LayoutAttr dataFrom = rowMajorLayout(ctx, dataType, ciphertextSize);
     LayoutAttr filterFrom = rowMajorLayout(ctx, filterType, ciphertextSize);
     LayoutAttr resultTo = rowMajorLayout(ctx, outputType, ciphertextSize);
-
-    // Enumerate the candidate layouts. Only valid ones are kept.
-    SmallVector<ConvolutionLayout> configs;
-    for (bool interchangeRows : {false, true}) {
-      FailureOr<ConvolutionLayout> config = getMatvecDiagonalConvolutionLayout(
-          op, ciphertextSize, interchangeRows);
-      if (succeeded(config)) configs.push_back(*config);
-    }
-    if (configs.empty()) return;
 
     OpBuilder builder(op);
     SmallVector<Value> classInputs;
@@ -89,7 +117,7 @@ struct InsertEquivalentConvLayouts
     // The class consumes the original result, so it must come after `op`.
     builder.setInsertionPointAfter(op);
     auto classOp = equivalence::ClassOp::create(
-        builder, op.getLoc(), outputType, classInputs, /*leader=*/Value(),
+        builder, op->getLoc(), outputType, classInputs, /*leader=*/Value(),
         /*min_cost_index=*/IntegerAttr());
 
     // In either case, route the original convolution's users through the class
@@ -107,15 +135,22 @@ struct InsertEquivalentConvLayouts
     // Collect first so that erasing the originals does not disturb the walk.
     SmallVector<Operation*> convs;
     getOperation()->walk([&](Operation* op) {
-      if (isa<linalg::Conv2DNchwFchwOp, linalg::Conv1DNcwFcwOp>(op))
+      if (isa<linalg::Conv2DNchwFchwOp, linalg::Conv1DNcwFcwOp,
+              linalg::Conv2DOp, linalg::Conv1DOp>(op))
         convs.push_back(op);
     });
 
     for (Operation* op : convs) {
+      SmallVector<ConvolutionLayout> configs;
       if (auto conv = dyn_cast<linalg::Conv2DNchwFchwOp>(op))
-        processConv(conv);
+        configs = enumerateLayouts(conv);
       else if (auto conv = dyn_cast<linalg::Conv1DNcwFcwOp>(op))
-        processConv(conv);
+        configs = enumerateLayouts(conv);
+      else if (auto conv = dyn_cast<linalg::Conv2DOp>(op))
+        configs = enumerateSingleChannelLayouts(conv);
+      else if (auto conv = dyn_cast<linalg::Conv1DOp>(op))
+        configs = enumerateSingleChannelLayouts(conv);
+      buildEquivalenceClass(op, configs);
     }
   }
 };

--- a/lib/Transforms/InsertEquivalentConvLayouts/InsertEquivalentConvLayouts.cpp
+++ b/lib/Transforms/InsertEquivalentConvLayouts/InsertEquivalentConvLayouts.cpp
@@ -1,0 +1,124 @@
+#include "lib/Transforms/InsertEquivalentConvLayouts/InsertEquivalentConvLayouts.h"
+
+#include <cstdint>
+
+#include "EquivalenceDialect.h"  // from @tamagoyaki
+#include "lib/Dialect/TensorExt/IR/TensorExtAttributes.h"
+#include "lib/Utils/Layout/ConvolutionLayoutBuilder.h"
+#include "lib/Utils/Layout/Utils.h"
+#include "llvm/include/llvm/ADT/SmallPtrSet.h"           // from @llvm-project
+#include "llvm/include/llvm/ADT/SmallVector.h"           // from @llvm-project
+#include "mlir/include/mlir/Dialect/Linalg/IR/Linalg.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Builders.h"               // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinAttributes.h"      // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"           // from @llvm-project
+#include "mlir/include/mlir/IR/MLIRContext.h"            // from @llvm-project
+#include "mlir/include/mlir/IR/Operation.h"              // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"                  // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"              // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+#define GEN_PASS_DEF_INSERTEQUIVALENTCONVLAYOUTS
+#include "lib/Transforms/InsertEquivalentConvLayouts/InsertEquivalentConvLayouts.h.inc"
+
+using tensor_ext::LayoutAttr;
+
+namespace {
+
+// Returns the row-major layout attribute for `type`, used as the canonical
+// layout of a value that does not yet carry one.
+LayoutAttr rowMajorLayout(MLIRContext* ctx, RankedTensorType type,
+                          int64_t ciphertextSize) {
+  return LayoutAttr::getFromIntegerRelation(
+      ctx, getRowMajorLayoutRelation(type, ciphertextSize));
+}
+
+}  // namespace
+
+struct InsertEquivalentConvLayouts
+    : impl::InsertEquivalentConvLayoutsBase<InsertEquivalentConvLayouts> {
+  using InsertEquivalentConvLayoutsBase::InsertEquivalentConvLayoutsBase;
+
+  // Materializes every valid layout for `op` and groups the results in an
+  // equivalence.class. ConvOpTy is one of the multichannel linalg conv ops.
+  template <typename ConvOpTy>
+  void processConv(ConvOpTy op) {
+    MLIRContext* ctx = op.getContext();
+    auto dataType = cast<RankedTensorType>(op.getInputs().front().getType());
+    auto filterType = cast<RankedTensorType>(op.getInputs().back().getType());
+    auto outputType = cast<RankedTensorType>(op->getResult(0).getType());
+
+    // A layout-free value is treated as living in the canonical row-major
+    // layout; that is the `from` side of each operand conversion and the `to`
+    // side the variants are converted back to so they are interchangeable.
+    LayoutAttr dataFrom = rowMajorLayout(ctx, dataType, ciphertextSize);
+    LayoutAttr filterFrom = rowMajorLayout(ctx, filterType, ciphertextSize);
+    LayoutAttr resultTo = rowMajorLayout(ctx, outputType, ciphertextSize);
+
+    // Enumerate the candidate layouts. Only valid ones are kept.
+    SmallVector<ConvolutionLayout> configs;
+    for (bool interchangeRows : {false, true}) {
+      FailureOr<ConvolutionLayout> config = getMatvecDiagonalConvolutionLayout(
+          op, ciphertextSize, interchangeRows);
+      if (succeeded(config)) configs.push_back(*config);
+    }
+    if (configs.empty()) return;
+
+    OpBuilder builder(op);
+    SmallVector<Value> classInputs;
+    for (const ConvolutionLayout& config : configs) {
+      FailureOr<ConvolutionLayoutOps> ops = buildConvolutionWithLayout(
+          op, dataFrom, filterFrom, resultTo, config);
+      if (failed(ops)) continue;
+      // Insert the detached chain (defs before uses) right before `op`.
+      builder.insert(ops->dataConvert);
+      builder.insert(ops->filterConvert);
+      builder.insert(ops->conv);
+      builder.insert(ops->resultConvert);
+      classInputs.push_back(ops->resultConvert.getResult());
+    }
+    if (classInputs.empty()) return;
+
+    // Unless it is removed, the original convolution is itself an equivalent
+    // implementation, so it joins the class as another member.
+    Value origResult = op->getResult(0);
+    if (!removeOriginal) classInputs.push_back(origResult);
+
+    // The class consumes the original result, so it must come after `op`.
+    builder.setInsertionPointAfter(op);
+    auto classOp = equivalence::ClassOp::create(
+        builder, op.getLoc(), outputType, classInputs, /*leader=*/Value(),
+        /*min_cost_index=*/IntegerAttr());
+
+    // In either case, route the original convolution's users through the class
+    // result, skipping the class's own use of it when the original is a member.
+    if (removeOriginal) {
+      origResult.replaceAllUsesWith(classOp.getResult());
+      op->erase();
+    } else {
+      SmallPtrSet<Operation*, 1> except{classOp};
+      origResult.replaceAllUsesExcept(classOp.getResult(), except);
+    }
+  }
+
+  void runOnOperation() override {
+    // Collect first so that erasing the originals does not disturb the walk.
+    SmallVector<Operation*> convs;
+    getOperation()->walk([&](Operation* op) {
+      if (isa<linalg::Conv2DNchwFchwOp, linalg::Conv1DNcwFcwOp>(op))
+        convs.push_back(op);
+    });
+
+    for (Operation* op : convs) {
+      if (auto conv = dyn_cast<linalg::Conv2DNchwFchwOp>(op))
+        processConv(conv);
+      else if (auto conv = dyn_cast<linalg::Conv1DNcwFcwOp>(op))
+        processConv(conv);
+    }
+  }
+};
+
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Transforms/InsertEquivalentConvLayouts/InsertEquivalentConvLayouts.h
+++ b/lib/Transforms/InsertEquivalentConvLayouts/InsertEquivalentConvLayouts.h
@@ -1,0 +1,18 @@
+#ifndef LIB_TRANSFORMS_INSERTEQUIVALENTCONVLAYOUTS_INSERTEQUIVALENTCONVLAYOUTS_H_
+#define LIB_TRANSFORMS_INSERTEQUIVALENTCONVLAYOUTS_INSERTEQUIVALENTCONVLAYOUTS_H_
+
+#include "mlir/include/mlir/Pass/Pass.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+#define GEN_PASS_DECL
+#include "lib/Transforms/InsertEquivalentConvLayouts/InsertEquivalentConvLayouts.h.inc"
+
+#define GEN_PASS_REGISTRATION
+#include "lib/Transforms/InsertEquivalentConvLayouts/InsertEquivalentConvLayouts.h.inc"
+
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_TRANSFORMS_INSERTEQUIVALENTCONVLAYOUTS_INSERTEQUIVALENTCONVLAYOUTS_H_

--- a/lib/Transforms/InsertEquivalentConvLayouts/InsertEquivalentConvLayouts.td
+++ b/lib/Transforms/InsertEquivalentConvLayouts/InsertEquivalentConvLayouts.td
@@ -1,0 +1,40 @@
+#ifndef LIB_TRANSFORMS_INSERTEQUIVALENTCONVLAYOUTS_INSERTEQUIVALENTCONVLAYOUTS_TD_
+#define LIB_TRANSFORMS_INSERTEQUIVALENTCONVLAYOUTS_INSERTEQUIVALENTCONVLAYOUTS_TD_
+
+include "mlir/Pass/PassBase.td"
+
+def InsertEquivalentConvLayouts : Pass<"insert-equivalent-conv-layouts"> {
+  let summary = "Materialize several layout assignments for each convolution.";
+  let description = [{
+    For every multichannel convolution, this pass generates multiple valid
+    layout assignments (e.g. the Halevi-Shoup MatvecDiagonal packing with and
+    without the pixel-shuffle row-interchange optimization). Each assignment is
+    materialized as its own chain of `tensor_ext.convert_layout` ops feeding a
+    copy of the convolution and a trailing conversion back to a common layout,
+    inserted alongside the original op.
+
+    The results of these trailing conversions are collected as the operands of
+    an `equivalence.class` op, which records that they are interchangeable
+    implementations of the same value. Users of the original convolution are
+    rerouted to read the class result, so downstream e-graph extraction can
+    select among the members.
+
+    With `remove-original`, the original convolution is erased. Otherwise it is
+    kept and added to the class as another equivalent member.
+  }];
+  let dependentDialects = [
+    "mlir::heir::tensor_ext::TensorExtDialect",
+    "mlir::heir::secret::SecretDialect",
+    "mlir::linalg::LinalgDialect",
+    "mlir::equivalence::EquivalenceDialect",
+  ];
+  let options = [
+    Option<"ciphertextSize", "ciphertext-size", "int", /*default=*/"1024",
+           "Power of two length of the ciphertexts the data is packed in.">,
+    Option<"removeOriginal", "remove-original", "bool", /*default=*/"false",
+           "If true, replace the original convolution with the "
+           "equivalence.class result and erase it.">,
+  ];
+}
+
+#endif  // LIB_TRANSFORMS_INSERTEQUIVALENTCONVLAYOUTS_INSERTEQUIVALENTCONVLAYOUTS_TD_

--- a/lib/Transforms/InsertEquivalentConvLayouts/InsertEquivalentConvLayouts.td
+++ b/lib/Transforms/InsertEquivalentConvLayouts/InsertEquivalentConvLayouts.td
@@ -6,21 +6,33 @@ include "mlir/Pass/PassBase.td"
 def InsertEquivalentConvLayouts : Pass<"insert-equivalent-conv-layouts"> {
   let summary = "Materialize several layout assignments for each convolution.";
   let description = [{
-    For every multichannel convolution, this pass generates multiple valid
-    layout assignments (e.g. the Halevi-Shoup MatvecDiagonal packing with and
-    without the pixel-shuffle row-interchange optimization). Each assignment is
-    materialized as its own chain of `tensor_ext.convert_layout` ops feeding a
-    copy of the convolution and a trailing conversion back to a common layout,
-    inserted alongside the original op.
+    For every convolution (the multichannel `linalg.conv_1d_ncw_fcw` and
+    `linalg.conv_2d_nchw_fchw`, as well as the single-channel `linalg.conv_1d`
+    and `linalg.conv_2d`), this pass generates several valid layout assignments
+    and records that they are interchangeable.
 
-    The results of these trailing conversions are collected as the operands of
-    an `equivalence.class` op, which records that they are interchangeable
-    implementations of the same value. Users of the original convolution are
-    rerouted to read the class result, so downstream e-graph extraction can
-    select among the members.
+    The candidates are:
+
+      * the Halevi-Shoup `MatvecDiagonal` packing (for multichannel convs, both
+        with and without the pixel-shuffle row-interchange optimization; the two
+        coincide for stride 1 and are then deduplicated), and
+      * the naive `MatvecNaive` packing, in which the expanded Toeplitz filter
+        matrix is laid out row-major instead of diagonalized.
+
+    Each candidate is materialized as its own chain of `tensor_ext.convert_layout`
+    ops feeding a copy of the convolution (carrying its `tensor_ext.layout` and
+    `secret.kernel` attributes) and a trailing conversion back to a common
+    layout, inserted alongside the original op. The results of these trailing
+    conversions become the operands of an `equivalence.class` op, and users of
+    the original convolution are rerouted to read the class result, so
+    downstream e-graph extraction can select among the members.
 
     With `remove-original`, the original convolution is erased. Otherwise it is
     kept and added to the class as another equivalent member.
+
+    Note: the `MatvecNaive` kernel does not yet have a lowering (TODO(#1589)).
+    Its candidate is a sound layout assignment for exploration, but a program
+    that selects it cannot currently be lowered end-to-end.
   }];
   let dependentDialects = [
     "mlir::heir::tensor_ext::TensorExtDialect",

--- a/lib/Utils/Layout/BUILD
+++ b/lib/Utils/Layout/BUILD
@@ -77,6 +77,25 @@ cc_library(
 )
 
 cc_library(
+    name = "ConvolutionLayoutBuilder",
+    srcs = ["ConvolutionLayoutBuilder.cpp"],
+    hdrs = ["ConvolutionLayoutBuilder.h"],
+    deps = [
+        ":Convolution",
+        ":Utils",
+        "@heir//lib/Dialect/Secret/IR:Dialect",
+        "@heir//lib/Dialect/TensorExt/IR:Dialect",
+        "@heir//lib/Kernel",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:Analysis",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:LinalgDialect",
+        "@llvm-project//mlir:LinalgInterfaces",
+        "@llvm-project//mlir:Support",
+    ],
+)
+
+cc_library(
     name = "Evaluate",
     srcs = ["Evaluate.cpp"],
     hdrs = ["Evaluate.h"],

--- a/lib/Utils/Layout/ConvolutionLayoutBuilder.cpp
+++ b/lib/Utils/Layout/ConvolutionLayoutBuilder.cpp
@@ -129,6 +129,79 @@ FailureOr<ConvolutionLayout> getMatvecDiagonalConvolutionLayout(
   return getSingleChannelLayout(op, ciphertextSize);
 }
 
+// Assembles the naive layout from an already-expanded (Toeplitz) filter
+// relation: data row-major, the expanded matrix packed row-major (rather than
+// diagonalized), result row-major, MatvecNaive kernel.
+static FailureOr<ConvolutionLayout> makeNaiveLayout(
+    MLIRContext* ctx, RankedTensorType dataType, RankedTensorType filterType,
+    RankedTensorType outputType, IntegerRelation expandedFilterRelation,
+    int64_t ciphertextSize) {
+  FailureOr<IntegerRelation> filterRelation =
+      rowMajorize2dMatrix(expandedFilterRelation, filterType, ciphertextSize);
+  if (failed(filterRelation)) return failure();
+
+  ConvolutionLayout layout;
+  layout.dataLayout = LayoutAttr::getFromIntegerRelation(
+      ctx, getRowMajorLayoutRelation(dataType, ciphertextSize));
+  layout.filterLayout =
+      LayoutAttr::getFromIntegerRelation(ctx, *filterRelation);
+  layout.resultLayout = LayoutAttr::getFromIntegerRelation(
+      ctx, getRowMajorLayoutRelation(outputType, ciphertextSize));
+  layout.kernel = secret::KernelAttr::get(ctx, KernelName::MatvecNaive,
+                                          /*force=*/false);
+  return layout;
+}
+
+FailureOr<ConvolutionLayout> getMatvecNaiveConvolutionLayout(
+    linalg::Conv2DNchwFchwOp op, int64_t ciphertextSize) {
+  auto dataType = cast<RankedTensorType>(op.getInputs().front().getType());
+  auto filterType = cast<RankedTensorType>(op.getInputs().back().getType());
+  auto outputType = cast<RankedTensorType>(op->getResult(0).getType());
+  SmallVector<int64_t> strides(op.getStrides().getValues<int64_t>().begin(),
+                               op.getStrides().getValues<int64_t>().end());
+  return makeNaiveLayout(
+      op.getContext(), dataType, filterType, outputType,
+      get2dConvChwFchwFilterRelation(filterType, dataType, strides,
+                                     /*padding=*/0),
+      ciphertextSize);
+}
+
+FailureOr<ConvolutionLayout> getMatvecNaiveConvolutionLayout(
+    linalg::Conv1DNcwFcwOp op, int64_t ciphertextSize) {
+  auto dataType = cast<RankedTensorType>(op.getInputs().front().getType());
+  auto filterType = cast<RankedTensorType>(op.getInputs().back().getType());
+  auto outputType = cast<RankedTensorType>(op->getResult(0).getType());
+  int64_t stride = op.getStrides().getValues<int64_t>().begin()[0];
+  return makeNaiveLayout(
+      op.getContext(), dataType, filterType, outputType,
+      get1dConvCwFcwFilterRelation(filterType, dataType, stride, /*padding=*/0),
+      ciphertextSize);
+}
+
+FailureOr<ConvolutionLayout> getMatvecNaiveConvolutionLayout(
+    linalg::Conv1DOp op, int64_t ciphertextSize) {
+  auto dataType = cast<RankedTensorType>(op.getInputs().front().getType());
+  auto filterType = cast<RankedTensorType>(op.getInputs().back().getType());
+  auto outputType = cast<RankedTensorType>(op->getResult(0).getType());
+  return makeNaiveLayout(
+      op.getContext(), dataType, filterType, outputType,
+      get1dConvFilterRelation(filterType, dataType, /*stride=*/1,
+                              /*padding=*/0),
+      ciphertextSize);
+}
+
+FailureOr<ConvolutionLayout> getMatvecNaiveConvolutionLayout(
+    linalg::Conv2DOp op, int64_t ciphertextSize) {
+  auto dataType = cast<RankedTensorType>(op.getInputs().front().getType());
+  auto filterType = cast<RankedTensorType>(op.getInputs().back().getType());
+  auto outputType = cast<RankedTensorType>(op->getResult(0).getType());
+  return makeNaiveLayout(
+      op.getContext(), dataType, filterType, outputType,
+      get2dConvFilterRelation(filterType, dataType, /*strides=*/{1, 1},
+                              /*padding=*/0),
+      ciphertextSize);
+}
+
 namespace {
 
 // Creates a detached convert_layout op (built via OperationState so it is never

--- a/lib/Utils/Layout/ConvolutionLayoutBuilder.cpp
+++ b/lib/Utils/Layout/ConvolutionLayoutBuilder.cpp
@@ -1,0 +1,162 @@
+#include "lib/Utils/Layout/ConvolutionLayoutBuilder.h"
+
+#include <cstdint>
+
+#include "lib/Dialect/Secret/IR/SecretAttributes.h"
+#include "lib/Dialect/Secret/IR/SecretDialect.h"
+#include "lib/Dialect/TensorExt/IR/TensorExtAttributes.h"
+#include "lib/Dialect/TensorExt/IR/TensorExtDialect.h"
+#include "lib/Dialect/TensorExt/IR/TensorExtOps.h"
+#include "lib/Kernel/KernelName.h"
+#include "lib/Utils/Layout/Convolution.h"
+#include "lib/Utils/Layout/Utils.h"
+#include "llvm/include/llvm/ADT/SmallVector.h"  // from @llvm-project
+#include "mlir/include/mlir/Analysis/Presburger/IntegerRelation.h"  // from @llvm-project
+#include "mlir/include/mlir/Dialect/Linalg/IR/Linalg.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Builders.h"               // from @llvm-project
+#include "mlir/include/mlir/IR/BuiltinTypes.h"           // from @llvm-project
+#include "mlir/include/mlir/IR/MLIRContext.h"            // from @llvm-project
+#include "mlir/include/mlir/IR/Operation.h"              // from @llvm-project
+#include "mlir/include/mlir/IR/OperationSupport.h"       // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"                  // from @llvm-project
+#include "mlir/include/mlir/Interfaces/DestinationStyleOpInterface.h"  // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"  // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+using presburger::IntegerRelation;
+using tensor_ext::ConvertLayoutOp;
+using tensor_ext::LayoutAttr;
+
+FailureOr<ConvolutionLayout> getMatvecDiagonalConvolutionLayout(
+    linalg::Conv2DNchwFchwOp op, int64_t ciphertextSize, bool interchangeRows) {
+  MLIRContext* ctx = op.getContext();
+  auto dataType = cast<RankedTensorType>(op.getInputs().front().getType());
+  auto filterType = cast<RankedTensorType>(op.getInputs().back().getType());
+  auto outputType = cast<RankedTensorType>(op->getResult(0).getType());
+
+  SmallVector<int64_t> strides(op.getStrides().getValues<int64_t>().begin(),
+                               op.getStrides().getValues<int64_t>().end());
+
+  IntegerRelation dataRelation =
+      getRowMajorLayoutRelation(dataType, ciphertextSize);
+  FailureOr<IntegerRelation> filterRelation =
+      get2dConvChwFchwFilterDiagonalizedRelation(filterType, dataType, strides,
+                                                 /*padding=*/0, ciphertextSize,
+                                                 interchangeRows);
+  if (failed(filterRelation)) return failure();
+  IntegerRelation resultRelation = get2dConvResultRelation(
+      outputType, strides, /*padding=*/0, ciphertextSize, interchangeRows);
+
+  ConvolutionLayout layout;
+  layout.dataLayout = LayoutAttr::getFromIntegerRelation(ctx, dataRelation);
+  layout.filterLayout =
+      LayoutAttr::getFromIntegerRelation(ctx, *filterRelation);
+  layout.resultLayout = LayoutAttr::getFromIntegerRelation(ctx, resultRelation);
+  layout.kernel = secret::KernelAttr::get(ctx, KernelName::MatvecDiagonal,
+                                          /*force=*/false);
+  // Matches the schedule the layout-propagation pass uses for the diagonalized
+  // filter conversion.
+  layout.filterDomainSchedule = {0, 1};
+  return layout;
+}
+
+FailureOr<ConvolutionLayout> getMatvecDiagonalConvolutionLayout(
+    linalg::Conv1DNcwFcwOp op, int64_t ciphertextSize, bool interchangeRows) {
+  MLIRContext* ctx = op.getContext();
+  auto dataType = cast<RankedTensorType>(op.getInputs().front().getType());
+  auto filterType = cast<RankedTensorType>(op.getInputs().back().getType());
+  auto outputType = cast<RankedTensorType>(op->getResult(0).getType());
+
+  int64_t stride = op.getStrides().getValues<int64_t>().begin()[0];
+
+  IntegerRelation dataRelation =
+      getRowMajorLayoutRelation(dataType, ciphertextSize);
+  FailureOr<IntegerRelation> filterRelation =
+      get1dConvCwFcwFilterDiagonalizedRelation(filterType, dataType, stride,
+                                               /*padding=*/0, ciphertextSize,
+                                               interchangeRows);
+  if (failed(filterRelation)) return failure();
+  IntegerRelation resultRelation = get1dConvResultRelation(
+      outputType, stride, /*padding=*/0, ciphertextSize, interchangeRows);
+
+  ConvolutionLayout layout;
+  layout.dataLayout = LayoutAttr::getFromIntegerRelation(ctx, dataRelation);
+  layout.filterLayout =
+      LayoutAttr::getFromIntegerRelation(ctx, *filterRelation);
+  layout.resultLayout = LayoutAttr::getFromIntegerRelation(ctx, resultRelation);
+  layout.kernel = secret::KernelAttr::get(ctx, KernelName::MatvecDiagonal,
+                                          /*force=*/false);
+  layout.filterDomainSchedule = {0, 1};
+  return layout;
+}
+
+namespace {
+
+// Creates a detached convert_layout op that re-packs `value` from `fromLayout`
+// to `toLayout`. The op is built via an OperationState and Operation::create so
+// that it is never inserted into a block. We also stamp the target layout on
+// the op as a `tensor_ext.layout` attribute, matching the convention used
+// elsewhere in the layout pipeline.
+ConvertLayoutOp createDetachedConvertLayout(OpBuilder& builder, Location loc,
+                                            Value value, LayoutAttr fromLayout,
+                                            LayoutAttr toLayout,
+                                            ArrayRef<int64_t> domainSchedule) {
+  OperationState state(loc, ConvertLayoutOp::getOperationName());
+  ConvertLayoutOp::build(builder, state, value, fromLayout, toLayout,
+                         builder.getDenseI64ArrayAttr(domainSchedule));
+  auto convertOp = cast<ConvertLayoutOp>(Operation::create(state));
+  convertOp->setAttr(tensor_ext::TensorExtDialect::kLayoutAttrName, toLayout);
+  return convertOp;
+}
+
+}  // namespace
+
+FailureOr<ConvolutionLayoutOps> buildConvolutionWithLayout(
+    Operation* convOp, LayoutAttr dataFromLayout, LayoutAttr filterFromLayout,
+    LayoutAttr resultToLayout, const ConvolutionLayout& layout) {
+  auto dpsOp = dyn_cast<DestinationStyleOpInterface>(convOp);
+  if (!dpsOp || dpsOp.getNumDpsInputs() != 2 || convOp->getNumResults() != 1) {
+    return failure();
+  }
+
+  OpOperand* dataOperand = dpsOp.getDpsInputOperand(0);
+  OpOperand* filterOperand = dpsOp.getDpsInputOperand(1);
+  unsigned dataOperandIdx = dataOperand->getOperandNumber();
+  unsigned filterOperandIdx = filterOperand->getOperandNumber();
+  Value data = dataOperand->get();
+  Value filter = filterOperand->get();
+  Location loc = convOp->getLoc();
+
+  OpBuilder builder(convOp->getContext());
+
+  // 1 & 2. Re-pack the operands into the layouts the kernel expects.
+  ConvertLayoutOp dataConvert =
+      createDetachedConvertLayout(builder, loc, data, dataFromLayout,
+                                  layout.dataLayout, layout.dataDomainSchedule);
+  ConvertLayoutOp filterConvert = createDetachedConvertLayout(
+      builder, loc, filter, filterFromLayout, layout.filterLayout,
+      layout.filterDomainSchedule);
+
+  // 3. Clone the conv (a detached copy preserving op type, strides, dilations,
+  // ...), point it at the re-packed operands, and annotate it with the result
+  // layout and the selected kernel. The original `convOp` is untouched.
+  Operation* newConv = convOp->clone();
+  newConv->setOperand(dataOperandIdx, dataConvert.getResult());
+  newConv->setOperand(filterOperandIdx, filterConvert.getResult());
+  newConv->setAttr(tensor_ext::TensorExtDialect::kLayoutAttrName,
+                   layout.resultLayout);
+  newConv->setAttr(secret::SecretDialect::kKernelAttrName, layout.kernel);
+
+  // 4. Convert the result back to the layout downstream consumers expect.
+  ConvertLayoutOp resultConvert = createDetachedConvertLayout(
+      builder, loc, newConv->getResult(0), layout.resultLayout, resultToLayout,
+      /*domainSchedule=*/{});
+
+  return ConvolutionLayoutOps{dataConvert, filterConvert, newConv,
+                              resultConvert};
+}
+
+}  // namespace heir
+}  // namespace mlir

--- a/lib/Utils/Layout/ConvolutionLayoutBuilder.cpp
+++ b/lib/Utils/Layout/ConvolutionLayoutBuilder.cpp
@@ -92,6 +92,43 @@ FailureOr<ConvolutionLayout> getMatvecDiagonalConvolutionLayout(
   return layout;
 }
 
+// Shared implementation for the single-channel conv ops, which differ only in
+// their op type: data row-major, filter diagonalized (no row-interchange
+// variant), result row-major, MatvecDiagonal kernel.
+template <typename ConvOpTy>
+static FailureOr<ConvolutionLayout> getSingleChannelLayout(
+    ConvOpTy op, int64_t ciphertextSize) {
+  MLIRContext* ctx = op.getContext();
+  auto dataType = cast<RankedTensorType>(op.getInputs().front().getType());
+  auto filterType = cast<RankedTensorType>(op.getInputs().back().getType());
+  auto outputType = cast<RankedTensorType>(op->getResult(0).getType());
+
+  FailureOr<IntegerRelation> filterRelation = getConvFilterDiagonalizedRelation(
+      filterType, dataType, /*padding=*/0, ciphertextSize);
+  if (failed(filterRelation)) return failure();
+
+  ConvolutionLayout layout;
+  layout.dataLayout = LayoutAttr::getFromIntegerRelation(
+      ctx, getRowMajorLayoutRelation(dataType, ciphertextSize));
+  layout.filterLayout =
+      LayoutAttr::getFromIntegerRelation(ctx, *filterRelation);
+  layout.resultLayout = LayoutAttr::getFromIntegerRelation(
+      ctx, getRowMajorLayoutRelation(outputType, ciphertextSize));
+  layout.kernel = secret::KernelAttr::get(ctx, KernelName::MatvecDiagonal,
+                                          /*force=*/false);
+  return layout;
+}
+
+FailureOr<ConvolutionLayout> getMatvecDiagonalConvolutionLayout(
+    linalg::Conv1DOp op, int64_t ciphertextSize) {
+  return getSingleChannelLayout(op, ciphertextSize);
+}
+
+FailureOr<ConvolutionLayout> getMatvecDiagonalConvolutionLayout(
+    linalg::Conv2DOp op, int64_t ciphertextSize) {
+  return getSingleChannelLayout(op, ciphertextSize);
+}
+
 namespace {
 
 // Creates a detached convert_layout op (built via OperationState so it is never

--- a/lib/Utils/Layout/ConvolutionLayoutBuilder.cpp
+++ b/lib/Utils/Layout/ConvolutionLayoutBuilder.cpp
@@ -94,11 +94,9 @@ FailureOr<ConvolutionLayout> getMatvecDiagonalConvolutionLayout(
 
 namespace {
 
-// Creates a detached convert_layout op that re-packs `value` from `fromLayout`
-// to `toLayout`. The op is built via an OperationState and Operation::create so
-// that it is never inserted into a block. We also stamp the target layout on
-// the op as a `tensor_ext.layout` attribute, matching the convention used
-// elsewhere in the layout pipeline.
+// Creates a detached convert_layout op (built via OperationState so it is never
+// inserted into a block) that re-packs `value` from `fromLayout` to `toLayout`,
+// stamping the target layout as a `tensor_ext.layout` attribute.
 ConvertLayoutOp createDetachedConvertLayout(OpBuilder& builder, Location loc,
                                             Value value, LayoutAttr fromLayout,
                                             LayoutAttr toLayout,

--- a/lib/Utils/Layout/ConvolutionLayoutBuilder.cpp
+++ b/lib/Utils/Layout/ConvolutionLayoutBuilder.cpp
@@ -17,7 +17,6 @@
 #include "mlir/include/mlir/IR/BuiltinTypes.h"           // from @llvm-project
 #include "mlir/include/mlir/IR/MLIRContext.h"            // from @llvm-project
 #include "mlir/include/mlir/IR/Operation.h"              // from @llvm-project
-#include "mlir/include/mlir/IR/OperationSupport.h"       // from @llvm-project
 #include "mlir/include/mlir/IR/Value.h"                  // from @llvm-project
 #include "mlir/include/mlir/Interfaces/DestinationStyleOpInterface.h"  // from @llvm-project
 #include "mlir/include/mlir/Support/LLVM.h"  // from @llvm-project
@@ -204,17 +203,15 @@ FailureOr<ConvolutionLayout> getMatvecNaiveConvolutionLayout(
 
 namespace {
 
-// Creates a detached convert_layout op (built via OperationState so it is never
-// inserted into a block) that re-packs `value` from `fromLayout` to `toLayout`,
-// stamping the target layout as a `tensor_ext.layout` attribute.
+// Creates a convert_layout op that re-packs `value` from `fromLayout to
+// `toLayout`, stamping the target layout as a `tensor_ext.layout` attribute.
 ConvertLayoutOp createDetachedConvertLayout(OpBuilder& builder, Location loc,
                                             Value value, LayoutAttr fromLayout,
                                             LayoutAttr toLayout,
                                             ArrayRef<int64_t> domainSchedule) {
-  OperationState state(loc, ConvertLayoutOp::getOperationName());
-  ConvertLayoutOp::build(builder, state, value, fromLayout, toLayout,
-                         builder.getDenseI64ArrayAttr(domainSchedule));
-  auto convertOp = cast<ConvertLayoutOp>(Operation::create(state));
+  auto convertOp =
+      ConvertLayoutOp::create(builder, loc, value, fromLayout, toLayout,
+                              builder.getDenseI64ArrayAttr(domainSchedule));
   convertOp->setAttr(tensor_ext::TensorExtDialect::kLayoutAttrName, toLayout);
   return convertOp;
 }

--- a/lib/Utils/Layout/ConvolutionLayoutBuilder.h
+++ b/lib/Utils/Layout/ConvolutionLayoutBuilder.h
@@ -1,0 +1,124 @@
+#ifndef LIB_UTILS_LAYOUT_CONVOLUTIONLAYOUTBUILDER_H_
+#define LIB_UTILS_LAYOUT_CONVOLUTIONLAYOUTBUILDER_H_
+
+#include <cstdint>
+
+#include "lib/Dialect/Secret/IR/SecretAttributes.h"
+#include "lib/Dialect/TensorExt/IR/TensorExtAttributes.h"
+#include "lib/Dialect/TensorExt/IR/TensorExtOps.h"
+#include "llvm/include/llvm/ADT/SmallVector.h"           // from @llvm-project
+#include "mlir/include/mlir/Dialect/Linalg/IR/Linalg.h"  // from @llvm-project
+#include "mlir/include/mlir/IR/Operation.h"              // from @llvm-project
+#include "mlir/include/mlir/IR/Value.h"                  // from @llvm-project
+#include "mlir/include/mlir/Support/LLVM.h"              // from @llvm-project
+
+namespace mlir {
+namespace heir {
+
+// A fully-specified, internally consistent packing choice for a single
+// convolution op. The four fields must agree with each other: `kernel` is the
+// kernel that will implement the conv, and `dataLayout` / `filterLayout` /
+// `resultLayout` are the slot layouts that kernel expects its data operand,
+// filter operand, and result to be in, respectively.
+//
+// Build instances with the factory functions below, which guarantee a valid
+// combination, or assemble one by hand for a configuration not yet covered by a
+// factory. The mechanical builder `convertConvolutionToLayout` does not check
+// validity -- it simply materializes whatever layouts this struct names.
+struct ConvolutionLayout {
+  tensor_ext::LayoutAttr dataLayout;
+  tensor_ext::LayoutAttr filterLayout;
+  tensor_ext::LayoutAttr resultLayout;
+  secret::KernelAttr kernel;
+
+  // Optional domain-schedule hints forwarded to the operand convert_layout ops.
+  // These do not change semantics; they only steer ISL toward an efficient loop
+  // nest when the conversion is later lowered. Leave empty if unsure.
+  SmallVector<int64_t> dataDomainSchedule;
+  SmallVector<int64_t> filterDomainSchedule;
+};
+
+// Factory: the Halevi-Shoup "MatvecDiagonal" packing for a 2-D multichannel
+// convolution (data laid out row-major, filter expanded to a diagonalized
+// Toeplitz matrix, result in the matching row-major-with-gap layout).
+//
+// `interchangeRows` toggles the pixel-shuffle / depth-to-space row-interchange
+// optimization on the filter and result relations. Both values produce a valid
+// configuration for the same MatvecDiagonal kernel; they differ only in the
+// resulting rotation cost.
+//
+// Returns failure if the diagonalized filter relation cannot be constructed
+// (e.g. the data does not fit the ciphertext size).
+FailureOr<ConvolutionLayout> getMatvecDiagonalConvolutionLayout(
+    linalg::Conv2DNchwFchwOp op, int64_t ciphertextSize, bool interchangeRows);
+
+// Factory: the MatvecDiagonal packing for a 1-D multichannel convolution. See
+// the 2-D overload for the meaning of `interchangeRows`.
+FailureOr<ConvolutionLayout> getMatvecDiagonalConvolutionLayout(
+    linalg::Conv1DNcwFcwOp op, int64_t ciphertextSize, bool interchangeRows);
+
+// The freshly-created ops that together re-express a convolution in a chosen
+// layout. They are produced detached (not inserted into any block) and wired to
+// each other: `conv` consumes the results of `dataConvert` / `filterConvert`,
+// and `resultConvert` consumes `conv`'s result.
+//
+// `resultConvert.getResult()` is the value intended to stand in for the
+// original convolution's result.
+struct ConvolutionLayoutOps {
+  // data --(dataFromLayout -> layout.dataLayout)--> data_l
+  tensor_ext::ConvertLayoutOp dataConvert;
+  // filter --(filterFromLayout -> layout.filterLayout)--> filter_l
+  tensor_ext::ConvertLayoutOp filterConvert;
+  // conv(data_l, filter_l) carrying layout.resultLayout + layout.kernel.
+  Operation* conv;
+  // conv_result --(layout.resultLayout -> resultToLayout)--> new_result
+  tensor_ext::ConvertLayoutOp resultConvert;
+};
+
+// Builds, but does NOT insert, the ops that re-express a layout-free
+// convolution
+//
+//     result = conv(data, filter)
+//
+// in the layout named by `layout`:
+//
+//     data_l   = tensor_ext.convert_layout data   {from = dataFromLayout,
+//                                                   to   = layout.dataLayout}
+//     filter_l = tensor_ext.convert_layout filter {from = filterFromLayout,
+//                                                   to   = layout.filterLayout}
+//     result_l = conv(data_l, filter_l)
+//                  {tensor_ext.layout = layout.resultLayout,
+//                   secret.kernel     = layout.kernel}
+//     new      = tensor_ext.convert_layout result_l {from =
+//     layout.resultLayout,
+//                                                     to   = resultToLayout}
+//
+// `convOp` is only read -- it is neither modified, replaced, nor erased, and no
+// uses are rewired, so the existing IR is left exactly as it was. The returned
+// ops are detached; it is the caller's responsibility to insert them (in the
+// order dataConvert, filterConvert, conv, resultConvert so that defs precede
+// uses) and to replace uses of the original result with
+// `result.resultConvert.getResult()`. The caller also owns the returned ops
+// until they are inserted (or destroyed).
+//
+// `convOp` must be a destination-style op with exactly two inputs (data,
+// filter) and a single result -- i.e. any of the linalg conv ops. The new conv
+// is a clone of `convOp`, so its op type and attributes (strides, dilations,
+// ...) are preserved.
+//
+// `dataFromLayout` / `filterFromLayout` are the operands' current layouts (the
+// `from` side of the operand conversions), and `resultToLayout` is the layout
+// downstream consumers expect (the `to` side of the trailing conversion).
+// These are explicit so a pass can supply them from whatever layout state it
+// tracks rather than this helper having to rediscover them.
+//
+// Returns failure if `convOp` does not match the expected shape.
+FailureOr<ConvolutionLayoutOps> buildConvolutionWithLayout(
+    Operation* convOp, tensor_ext::LayoutAttr dataFromLayout,
+    tensor_ext::LayoutAttr filterFromLayout,
+    tensor_ext::LayoutAttr resultToLayout, const ConvolutionLayout& layout);
+
+}  // namespace heir
+}  // namespace mlir
+
+#endif  // LIB_UTILS_LAYOUT_CONVOLUTIONLAYOUTBUILDER_H_

--- a/lib/Utils/Layout/ConvolutionLayoutBuilder.h
+++ b/lib/Utils/Layout/ConvolutionLayoutBuilder.h
@@ -15,104 +15,45 @@
 namespace mlir {
 namespace heir {
 
-// A fully-specified, internally consistent packing choice for a single
-// convolution op. The four fields must agree with each other: `kernel` is the
-// kernel that will implement the conv, and `dataLayout` / `filterLayout` /
-// `resultLayout` are the slot layouts that kernel expects its data operand,
-// filter operand, and result to be in, respectively.
-//
-// Build instances with the factory functions below, which guarantee a valid
-// combination, or assemble one by hand for a configuration not yet covered by a
-// factory. The mechanical builder `convertConvolutionToLayout` does not check
-// validity -- it simply materializes whatever layouts this struct names.
+// A self-consistent packing choice for a convolution: the layouts its data
+// operand, filter operand, and result must be in for the chosen `kernel`.
 struct ConvolutionLayout {
   tensor_ext::LayoutAttr dataLayout;
   tensor_ext::LayoutAttr filterLayout;
   tensor_ext::LayoutAttr resultLayout;
   secret::KernelAttr kernel;
 
-  // Optional domain-schedule hints forwarded to the operand convert_layout ops.
-  // These do not change semantics; they only steer ISL toward an efficient loop
-  // nest when the conversion is later lowered. Leave empty if unsure.
+  // Optional domain-schedule hints forwarded to the operand convert_layout ops
+  // to help ISL emit an efficient loop nest when lowering.
   SmallVector<int64_t> dataDomainSchedule;
   SmallVector<int64_t> filterDomainSchedule;
 };
 
-// Factory: the Halevi-Shoup "MatvecDiagonal" packing for a 2-D multichannel
-// convolution (data laid out row-major, filter expanded to a diagonalized
-// Toeplitz matrix, result in the matching row-major-with-gap layout).
-//
-// `interchangeRows` toggles the pixel-shuffle / depth-to-space row-interchange
-// optimization on the filter and result relations. Both values produce a valid
-// configuration for the same MatvecDiagonal kernel; they differ only in the
-// resulting rotation cost.
-//
-// Returns failure if the diagonalized filter relation cannot be constructed
-// (e.g. the data does not fit the ciphertext size).
+// Returns the Halevi-Shoup MatvecDiagonal packing for a multichannel
+// convolution. `interchangeRows` toggles the pixel-shuffle row-interchange
+// optimization. Fails if the diagonalized filter relation cannot be built.
 FailureOr<ConvolutionLayout> getMatvecDiagonalConvolutionLayout(
     linalg::Conv2DNchwFchwOp op, int64_t ciphertextSize, bool interchangeRows);
-
-// Factory: the MatvecDiagonal packing for a 1-D multichannel convolution. See
-// the 2-D overload for the meaning of `interchangeRows`.
 FailureOr<ConvolutionLayout> getMatvecDiagonalConvolutionLayout(
     linalg::Conv1DNcwFcwOp op, int64_t ciphertextSize, bool interchangeRows);
 
-// The freshly-created ops that together re-express a convolution in a chosen
-// layout. They are produced detached (not inserted into any block) and wired to
-// each other: `conv` consumes the results of `dataConvert` / `filterConvert`,
-// and `resultConvert` consumes `conv`'s result.
-//
-// `resultConvert.getResult()` is the value intended to stand in for the
-// original convolution's result.
+// The detached ops that re-express a convolution in a chosen layout, wired to
+// each other but not inserted into any block. `resultConvert.getResult()` is
+// the value meant to replace the original convolution result.
 struct ConvolutionLayoutOps {
-  // data --(dataFromLayout -> layout.dataLayout)--> data_l
   tensor_ext::ConvertLayoutOp dataConvert;
-  // filter --(filterFromLayout -> layout.filterLayout)--> filter_l
   tensor_ext::ConvertLayoutOp filterConvert;
-  // conv(data_l, filter_l) carrying layout.resultLayout + layout.kernel.
   Operation* conv;
-  // conv_result --(layout.resultLayout -> resultToLayout)--> new_result
   tensor_ext::ConvertLayoutOp resultConvert;
 };
 
-// Builds, but does NOT insert, the ops that re-express a layout-free
-// convolution
-//
-//     result = conv(data, filter)
-//
-// in the layout named by `layout`:
-//
-//     data_l   = tensor_ext.convert_layout data   {from = dataFromLayout,
-//                                                   to   = layout.dataLayout}
-//     filter_l = tensor_ext.convert_layout filter {from = filterFromLayout,
-//                                                   to   = layout.filterLayout}
-//     result_l = conv(data_l, filter_l)
-//                  {tensor_ext.layout = layout.resultLayout,
-//                   secret.kernel     = layout.kernel}
-//     new      = tensor_ext.convert_layout result_l {from =
-//     layout.resultLayout,
-//                                                     to   = resultToLayout}
-//
-// `convOp` is only read -- it is neither modified, replaced, nor erased, and no
-// uses are rewired, so the existing IR is left exactly as it was. The returned
-// ops are detached; it is the caller's responsibility to insert them (in the
-// order dataConvert, filterConvert, conv, resultConvert so that defs precede
-// uses) and to replace uses of the original result with
-// `result.resultConvert.getResult()`. The caller also owns the returned ops
-// until they are inserted (or destroyed).
-//
-// `convOp` must be a destination-style op with exactly two inputs (data,
-// filter) and a single result -- i.e. any of the linalg conv ops. The new conv
-// is a clone of `convOp`, so its op type and attributes (strides, dilations,
-// ...) are preserved.
-//
-// `dataFromLayout` / `filterFromLayout` are the operands' current layouts (the
-// `from` side of the operand conversions), and `resultToLayout` is the layout
-// downstream consumers expect (the `to` side of the trailing conversion).
-// These are explicit so a pass can supply them from whatever layout state it
-// tracks rather than this helper having to rediscover them.
-//
-// Returns failure if `convOp` does not match the expected shape.
+// Builds, without inserting, the ops re-expressing `conv(data, filter)` in
+// `layout`: a convert_layout for each operand (from its current layout to the
+// kernel's), a clone of the conv carrying the result layout and kernel, and a
+// convert_layout of the result back to `resultToLayout`. `convOp` is only read,
+// so the existing IR is left untouched; the caller inserts the returned ops
+// (data, filter, conv, result) and rewires uses. Fails if `convOp` is not a
+// destination-style op with two inputs and one result.
 FailureOr<ConvolutionLayoutOps> buildConvolutionWithLayout(
     Operation* convOp, tensor_ext::LayoutAttr dataFromLayout,
     tensor_ext::LayoutAttr filterFromLayout,

--- a/lib/Utils/Layout/ConvolutionLayoutBuilder.h
+++ b/lib/Utils/Layout/ConvolutionLayoutBuilder.h
@@ -37,6 +37,13 @@ FailureOr<ConvolutionLayout> getMatvecDiagonalConvolutionLayout(
 FailureOr<ConvolutionLayout> getMatvecDiagonalConvolutionLayout(
     linalg::Conv1DNcwFcwOp op, int64_t ciphertextSize, bool interchangeRows);
 
+// Returns the MatvecDiagonal packing for a single-channel convolution. There is
+// no row-interchange variant for these ops.
+FailureOr<ConvolutionLayout> getMatvecDiagonalConvolutionLayout(
+    linalg::Conv1DOp op, int64_t ciphertextSize);
+FailureOr<ConvolutionLayout> getMatvecDiagonalConvolutionLayout(
+    linalg::Conv2DOp op, int64_t ciphertextSize);
+
 // The detached ops that re-express a convolution in a chosen layout, wired to
 // each other but not inserted into any block. `resultConvert.getResult()` is
 // the value meant to replace the original convolution result.

--- a/lib/Utils/Layout/ConvolutionLayoutBuilder.h
+++ b/lib/Utils/Layout/ConvolutionLayoutBuilder.h
@@ -44,6 +44,20 @@ FailureOr<ConvolutionLayout> getMatvecDiagonalConvolutionLayout(
 FailureOr<ConvolutionLayout> getMatvecDiagonalConvolutionLayout(
     linalg::Conv2DOp op, int64_t ciphertextSize);
 
+// Returns the naive (non-diagonalized) MatvecDiagonal alternative for a
+// convolution: the expanded Toeplitz filter matrix is packed row-major and the
+// kernel is `MatvecNaive`. This is a sound layout assignment; note that the
+// `MatvecNaive` kernel does not yet have a lowering (TODO(#1589)), so this
+// configuration is meant for layout exploration, not end-to-end compilation.
+FailureOr<ConvolutionLayout> getMatvecNaiveConvolutionLayout(
+    linalg::Conv2DNchwFchwOp op, int64_t ciphertextSize);
+FailureOr<ConvolutionLayout> getMatvecNaiveConvolutionLayout(
+    linalg::Conv1DNcwFcwOp op, int64_t ciphertextSize);
+FailureOr<ConvolutionLayout> getMatvecNaiveConvolutionLayout(
+    linalg::Conv1DOp op, int64_t ciphertextSize);
+FailureOr<ConvolutionLayout> getMatvecNaiveConvolutionLayout(
+    linalg::Conv2DOp op, int64_t ciphertextSize);
+
 // The detached ops that re-express a convolution in a chosen layout, wired to
 // each other but not inserted into any block. `resultConvert.getResult()` is
 // the value meant to replace the original convolution result.

--- a/lib/Utils/Layout/Utils.cpp
+++ b/lib/Utils/Layout/Utils.cpp
@@ -359,6 +359,27 @@ FailureOr<presburger::IntegerRelation> diagonalize2dMatrix(
   return relation;
 }
 
+FailureOr<presburger::IntegerRelation> rowMajorize2dMatrix(
+    presburger::IntegerRelation relation, RankedTensorType originalType,
+    int64_t ciphertextSize) {
+  // Get size of the matrix.
+  auto rowBound = relation.getConstantBound64(
+      BoundType::UB, relation.getVarKindOffset(VarKind::Range));
+  auto colBound = relation.getConstantBound64(
+      BoundType::UB, relation.getVarKindOffset(VarKind::Range) + 1);
+  if (!rowBound.has_value() || !colBound.has_value()) {
+    return failure();
+  }
+  RankedTensorType matrixType =
+      RankedTensorType::get({rowBound.value() + 1, colBound.value() + 1},
+                            originalType.getElementType());
+  auto rowMajorRelation = getRowMajorLayoutRelation(matrixType, ciphertextSize);
+
+  // Compose these relations.
+  relation.compose(rowMajorRelation);
+  return relation;
+}
+
 presburger::IntegerRelation getBicyclicLayoutRelation(
     RankedTensorType matrixType, int64_t numSlots) {
   unsigned int rows = matrixType.getDimSize(0);

--- a/lib/Utils/Layout/Utils.h
+++ b/lib/Utils/Layout/Utils.h
@@ -78,6 +78,13 @@ FailureOr<presburger::IntegerRelation> diagonalize2dMatrix(
     presburger::IntegerRelation relation, RankedTensorType originalType,
     int64_t ciphertextSize);
 
+// Applies a row-major layout onto a given 2-D matrix layout. This is the
+// non-diagonalized counterpart of diagonalize2dMatrix, used to pack the
+// expanded matrix for a naive matvec kernel.
+FailureOr<presburger::IntegerRelation> rowMajorize2dMatrix(
+    presburger::IntegerRelation relation, RankedTensorType originalType,
+    int64_t ciphertextSize);
+
 // Returns an IntegerRelation that represents a bicyclic layout for a matrix.
 // See https://eprint.iacr.org/2024/1762 for details.
 presburger::IntegerRelation getBicyclicLayoutRelation(

--- a/tests/Transforms/insert_equivalent_conv_layouts/BUILD
+++ b/tests/Transforms/insert_equivalent_conv_layouts/BUILD
@@ -1,0 +1,13 @@
+load("//bazel:lit.bzl", "glob_lit_tests")
+
+package(default_applicable_licenses = ["@heir//:license"])
+
+glob_lit_tests(
+    name = "all_tests",
+    data = [
+        "@heir//tests:test_utilities",
+        "@heir//tools:tamagoyaki-demo",
+    ],
+    driver = "@heir//tests:run_lit.sh",
+    test_file_exts = ["mlir"],
+)

--- a/tests/Transforms/insert_equivalent_conv_layouts/conv1d.mlir
+++ b/tests/Transforms/insert_equivalent_conv_layouts/conv1d.mlir
@@ -1,13 +1,16 @@
 // RUN: tamagoyaki-demo --insert-equivalent-conv-layouts %s | FileCheck %s
 
-// The pass also handles 1-D multichannel convolutions.
+// The pass also handles 1-D multichannel convolutions, with the same three
+// variants (two MatvecDiagonal, one MatvecNaive).
 
+// CHECK-DAG: name = "MatvecDiagonal"
+// CHECK-DAG: name = "MatvecNaive"
 // CHECK: func.func @conv1d
-// CHECK-COUNT-2: linalg.conv_1d_ncw_fcw {{.*}}secret.kernel = #{{.*}}tensor_ext.layout
-// The kept original joins the class as a third member; the result is the class.
+// CHECK-COUNT-3: linalg.conv_1d_ncw_fcw {{.*}}secret.kernel = #{{.*}}tensor_ext.layout
+// The kept original joins the class as a fourth member; the result is the class.
 // CHECK: linalg.conv_1d_ncw_fcw
 // CHECK-NOT: secret.kernel
-// CHECK: %[[CLASS:.*]] = equivalence.class %{{[0-9]+}}, %{{[0-9]+}}, %{{[0-9]+}} : tensor<1x8x2xf32>
+// CHECK: %[[CLASS:.*]] = equivalence.class %{{[0-9]+}}, %{{[0-9]+}}, %{{[0-9]+}}, %{{[0-9]+}} : tensor<1x8x2xf32>
 // CHECK: return %[[CLASS]]
 
 func.func @conv1d(%arg0: tensor<1x1x4xf32>, %filter: tensor<8x1x2xf32>) -> tensor<1x8x2xf32> {

--- a/tests/Transforms/insert_equivalent_conv_layouts/conv1d.mlir
+++ b/tests/Transforms/insert_equivalent_conv_layouts/conv1d.mlir
@@ -1,0 +1,20 @@
+// RUN: tamagoyaki-demo --insert-equivalent-conv-layouts %s | FileCheck %s
+
+// The pass also handles 1-D multichannel convolutions.
+
+// CHECK: func.func @conv1d
+// CHECK-COUNT-2: linalg.conv_1d_ncw_fcw {{.*}}secret.kernel = #{{.*}}tensor_ext.layout
+// The kept original joins the class as a third member; the result is the class.
+// CHECK: linalg.conv_1d_ncw_fcw
+// CHECK-NOT: secret.kernel
+// CHECK: %[[CLASS:.*]] = equivalence.class %{{[0-9]+}}, %{{[0-9]+}}, %{{[0-9]+}} : tensor<1x8x2xf32>
+// CHECK: return %[[CLASS]]
+
+func.func @conv1d(%arg0: tensor<1x1x4xf32>, %filter: tensor<8x1x2xf32>) -> tensor<1x8x2xf32> {
+  %0 = tensor.empty() : tensor<1x8x2xf32>
+  %1 = linalg.conv_1d_ncw_fcw
+    {dilations = dense<1> : vector<1xi64>, strides = dense<2> : vector<1xi64>}
+    ins(%arg0, %filter : tensor<1x1x4xf32>, tensor<8x1x2xf32>)
+    outs(%0 : tensor<1x8x2xf32>) -> tensor<1x8x2xf32>
+  return %1 : tensor<1x8x2xf32>
+}

--- a/tests/Transforms/insert_equivalent_conv_layouts/conv2d.mlir
+++ b/tests/Transforms/insert_equivalent_conv_layouts/conv2d.mlir
@@ -1,27 +1,31 @@
 // RUN: tamagoyaki-demo --insert-equivalent-conv-layouts %s | FileCheck %s --check-prefix=KEEP
 // RUN: tamagoyaki-demo --insert-equivalent-conv-layouts=remove-original=true %s | FileCheck %s --check-prefix=REMOVE
 
-// Two layout variants are materialized for the convolution. Each is a copy of
-// the conv carrying a kernel and a result layout, fed by operand conversions
-// and followed by a conversion back to the common layout. The variant results
-// are grouped into an equivalence.class, and users of the original read the
-// class result.
+// Three layout variants are materialized for the convolution: the MatvecDiagonal
+// kernel with and without the pixel-shuffle row-interchange, and the naive
+// MatvecNaive packing. Each is a copy of the conv carrying a kernel and a result
+// layout, fed by operand conversions and followed by a conversion back to the
+// common layout. The variant results are grouped into an equivalence.class, and
+// users of the original read the class result.
 
+// KEEP-DAG: name = "MatvecDiagonal"
+// KEEP-DAG: name = "MatvecNaive"
 // KEEP-LABEL: func.func @conv2d
-// Each variant: operand conversions, then a conv with a kernel + layout.
-// KEEP-COUNT-2: linalg.conv_2d_nchw_fchw {{.*}}secret.kernel = #{{.*}}tensor_ext.layout
+// KEEP-COUNT-3: linalg.conv_2d_nchw_fchw {{.*}}secret.kernel = #{{.*}}tensor_ext.layout
 // The original, layout-free convolution is kept (no kernel) ...
 // KEEP: linalg.conv_2d_nchw_fchw
 // KEEP-NOT: secret.kernel
-// ... and joins the class as a third member; the result is the class result.
-// KEEP: %[[CLASS:.*]] = equivalence.class %{{[0-9]+}}, %{{[0-9]+}}, %{{[0-9]+}} : tensor<1x4x5x5xf32>
+// ... and joins the class as a fourth member; the result is the class result.
+// KEEP: %[[CLASS:.*]] = equivalence.class %{{[0-9]+}}, %{{[0-9]+}}, %{{[0-9]+}}, %{{[0-9]+}} : tensor<1x4x5x5xf32>
 // KEEP: return %[[CLASS]]
 
+// REMOVE-DAG: name = "MatvecDiagonal"
+// REMOVE-DAG: name = "MatvecNaive"
 // REMOVE-LABEL: func.func @conv2d
-// REMOVE-COUNT-2: linalg.conv_2d_nchw_fchw {{.*}}secret.kernel = #{{.*}}tensor_ext.layout
-// Exactly the two variants remain; the original conv is erased.
+// REMOVE-COUNT-3: linalg.conv_2d_nchw_fchw {{.*}}secret.kernel = #{{.*}}tensor_ext.layout
+// Exactly the three variants remain; the original conv is erased.
 // REMOVE-NOT: linalg.conv_2d_nchw_fchw
-// REMOVE: %[[CLASS:.*]] = equivalence.class %{{[0-9]+}}, %{{[0-9]+}} : tensor<1x4x5x5xf32>
+// REMOVE: %[[CLASS:.*]] = equivalence.class %{{[0-9]+}}, %{{[0-9]+}}, %{{[0-9]+}} : tensor<1x4x5x5xf32>
 // REMOVE: return %[[CLASS]]
 
 func.func @conv2d(%arg0: tensor<1x1x10x10xf32>, %filter: tensor<4x1x2x2xf32>) -> tensor<1x4x5x5xf32> {

--- a/tests/Transforms/insert_equivalent_conv_layouts/conv2d.mlir
+++ b/tests/Transforms/insert_equivalent_conv_layouts/conv2d.mlir
@@ -1,0 +1,34 @@
+// RUN: tamagoyaki-demo --insert-equivalent-conv-layouts %s | FileCheck %s --check-prefix=KEEP
+// RUN: tamagoyaki-demo --insert-equivalent-conv-layouts=remove-original=true %s | FileCheck %s --check-prefix=REMOVE
+
+// Two layout variants are materialized for the convolution. Each is a copy of
+// the conv carrying a kernel and a result layout, fed by operand conversions
+// and followed by a conversion back to the common layout. The variant results
+// are grouped into an equivalence.class, and users of the original read the
+// class result.
+
+// KEEP-LABEL: func.func @conv2d
+// Each variant: operand conversions, then a conv with a kernel + layout.
+// KEEP-COUNT-2: linalg.conv_2d_nchw_fchw {{.*}}secret.kernel = #{{.*}}tensor_ext.layout
+// The original, layout-free convolution is kept (no kernel) ...
+// KEEP: linalg.conv_2d_nchw_fchw
+// KEEP-NOT: secret.kernel
+// ... and joins the class as a third member; the result is the class result.
+// KEEP: %[[CLASS:.*]] = equivalence.class %{{[0-9]+}}, %{{[0-9]+}}, %{{[0-9]+}} : tensor<1x4x5x5xf32>
+// KEEP: return %[[CLASS]]
+
+// REMOVE-LABEL: func.func @conv2d
+// REMOVE-COUNT-2: linalg.conv_2d_nchw_fchw {{.*}}secret.kernel = #{{.*}}tensor_ext.layout
+// Exactly the two variants remain; the original conv is erased.
+// REMOVE-NOT: linalg.conv_2d_nchw_fchw
+// REMOVE: %[[CLASS:.*]] = equivalence.class %{{[0-9]+}}, %{{[0-9]+}} : tensor<1x4x5x5xf32>
+// REMOVE: return %[[CLASS]]
+
+func.func @conv2d(%arg0: tensor<1x1x10x10xf32>, %filter: tensor<4x1x2x2xf32>) -> tensor<1x4x5x5xf32> {
+  %0 = tensor.empty() : tensor<1x4x5x5xf32>
+  %1 = linalg.conv_2d_nchw_fchw
+    {dilations = dense<1> : vector<2xi64>, strides = dense<2> : vector<2xi64>}
+    ins(%arg0, %filter : tensor<1x1x10x10xf32>, tensor<4x1x2x2xf32>)
+    outs(%0 : tensor<1x4x5x5xf32>) -> tensor<1x4x5x5xf32>
+  return %1 : tensor<1x4x5x5xf32>
+}

--- a/tests/Transforms/insert_equivalent_conv_layouts/conv2d_single_channel.mlir
+++ b/tests/Transforms/insert_equivalent_conv_layouts/conv2d_single_channel.mlir
@@ -1,14 +1,16 @@
 // RUN: tamagoyaki-demo --insert-equivalent-conv-layouts %s | FileCheck %s
 
-// Single-channel convs (linalg.conv_2d) are also handled. They have a single
-// MatvecDiagonal layout (no row-interchange variant), so the class holds the
-// one materialized variant plus the original.
+// Single-channel convs (linalg.conv_2d) are also handled. They have no
+// row-interchange variant, so the candidates are the MatvecDiagonal packing and
+// the naive MatvecNaive packing, plus the original.
 
+// CHECK-DAG: name = "MatvecDiagonal"
+// CHECK-DAG: name = "MatvecNaive"
 // CHECK: func.func @conv2d_single
-// CHECK: linalg.conv_2d {{.*}}secret.kernel = #{{.*}}tensor_ext.layout
+// CHECK-COUNT-2: linalg.conv_2d {{.*}}secret.kernel = #{{.*}}tensor_ext.layout
 // CHECK: linalg.conv_2d
 // CHECK-NOT: secret.kernel
-// CHECK: %[[CLASS:.*]] = equivalence.class %{{[0-9]+}}, %{{[0-9]+}} : tensor<4x4xf32>
+// CHECK: %[[CLASS:.*]] = equivalence.class %{{[0-9]+}}, %{{[0-9]+}}, %{{[0-9]+}} : tensor<4x4xf32>
 // CHECK: return %[[CLASS]]
 
 func.func @conv2d_single(%arg0: tensor<6x6xf32>, %filter: tensor<3x3xf32>) -> tensor<4x4xf32> {

--- a/tests/Transforms/insert_equivalent_conv_layouts/conv2d_single_channel.mlir
+++ b/tests/Transforms/insert_equivalent_conv_layouts/conv2d_single_channel.mlir
@@ -1,0 +1,20 @@
+// RUN: tamagoyaki-demo --insert-equivalent-conv-layouts %s | FileCheck %s
+
+// Single-channel convs (linalg.conv_2d) are also handled. They have a single
+// MatvecDiagonal layout (no row-interchange variant), so the class holds the
+// one materialized variant plus the original.
+
+// CHECK: func.func @conv2d_single
+// CHECK: linalg.conv_2d {{.*}}secret.kernel = #{{.*}}tensor_ext.layout
+// CHECK: linalg.conv_2d
+// CHECK-NOT: secret.kernel
+// CHECK: %[[CLASS:.*]] = equivalence.class %{{[0-9]+}}, %{{[0-9]+}} : tensor<4x4xf32>
+// CHECK: return %[[CLASS]]
+
+func.func @conv2d_single(%arg0: tensor<6x6xf32>, %filter: tensor<3x3xf32>) -> tensor<4x4xf32> {
+  %0 = tensor.empty() : tensor<4x4xf32>
+  %1 = linalg.conv_2d
+    ins(%arg0, %filter : tensor<6x6xf32>, tensor<3x3xf32>)
+    outs(%0 : tensor<4x4xf32>) -> tensor<4x4xf32>
+  return %1 : tensor<4x4xf32>
+}

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -358,6 +358,9 @@ cc_binary(
     name = "tamagoyaki-demo",
     srcs = ["tamagoyaki-demo.cpp"],
     deps = [
+        "@heir//lib/Dialect/Secret/IR:Dialect",
+        "@heir//lib/Dialect/TensorExt/IR:Dialect",
+        "@heir//lib/Transforms/InsertEquivalentConvLayouts",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:MlirOptLib",
         "@llvm-project//mlir:RegisterAllDialects",

--- a/tools/tamagoyaki-demo.cpp
+++ b/tools/tamagoyaki-demo.cpp
@@ -1,5 +1,8 @@
 #include "EmatchDialect.h"
 #include "EquivalenceDialect.h"
+#include "lib/Dialect/Secret/IR/SecretDialect.h"
+#include "lib/Dialect/TensorExt/IR/TensorExtDialect.h"
+#include "lib/Transforms/InsertEquivalentConvLayouts/InsertEquivalentConvLayouts.h"
 #include "mlir/include/mlir/IR/DialectRegistry.h"          // from @llvm-project
 #include "mlir/include/mlir/InitAllDialects.h"             // from @llvm-project
 #include "mlir/include/mlir/Tools/mlir-opt/MlirOptMain.h"  // from @llvm-project
@@ -9,6 +12,11 @@ int main(int argc, char **argv) {
   mlir::registerAllDialects(registry);
   registry.insert<mlir::equivalence::EquivalenceDialect>();
   registry.insert<mlir::ematch::EmatchDialect>();
+  registry.insert<mlir::heir::secret::SecretDialect>();
+  registry.insert<mlir::heir::tensor_ext::TensorExtDialect>();
+
+  mlir::heir::registerInsertEquivalentConvLayouts();
+
   return mlir::asMainReturnCode(
       mlir::MlirOptMain(argc, argv, "Tamagoyaki Demo Driver", registry));
 }


### PR DESCRIPTION
This is some small experimentation on having a pass that inserts multiple different layouts for a convolution operation.
The changes consist of:
* Helper function (`ConvolutionLayoutBuilder`) to generate equivalent convolution operations with different layouts. These utilities do not actually insert any of the IR. They could also be used in a PDL flow when e-matching.
*  `InsertEquivalentConvLayouts` simply creates all these alternatives and inserts them alongside another in the IR, merging their results with an `equivalence.class` operation.

e.g.:
```
func.func @conv2d(%arg0: tensor<1x1x10x10xf32>, %filter: tensor<4x1x2x2xf32>) -> tensor<1x4x5x5xf32> {
  %0 = tensor.empty() : tensor<1x4x5x5xf32>
  %1 = linalg.conv_2d_nchw_fchw
    {dilations = dense<1> : vector<2xi64>, strides = dense<2> : vector<2xi64>}
    ins(%arg0, %filter : tensor<1x1x10x10xf32>, tensor<4x1x2x2xf32>)
    outs(%0 : tensor<1x4x5x5xf32>) -> tensor<1x4x5x5xf32>
  return %1 : tensor<1x4x5x5xf32>
}
```
becomes:
```
#kernel = #secret.kernel<name = "MatvecDiagonal", force = false>
#kernel1 = #secret.kernel<name = "MatvecNaive", force = false>
#layout = #tensor_ext.layout<"{ [i0, i1, i2, i3] -> [ct, slot] : i0 = 0 and i1 = 0 and ct = 0 and (-10i2 - i3 + slot) mod 128 = 0 and 0 <= i2 <= 9 and 0 <= i3 <= 9 and 0 <= slot <= 1023 }">
#layout1 = #tensor_ext.layout<"{ [i0, i1, i2, i3] -> [ct, slot] : i1 = 0 and ct = 0 and (-4i0 - 2i2 - i3 + slot) mod 16 = 0 and 0 <= i0 <= 3 and 0 <= i2 <= 1 and 0 <= i3 <= 1 and 0 <= slot <= 1023 }">
#layout2 = #tensor_ext.layout<"{ [i0, i1, i2, i3] -> [ct, slot] : i1 = 0 and (-28i0 - 10i2 - i3 + ct - slot + 4*floor((28 + slot)/128) - 10*floor((slot + 2*floor((28 + slot)/128))/5)) mod 128 = 0 and 0 <= i0 <= 3 and 0 <= i2 <= 1 and 0 <= i3 <= 1 and 0 <= ct <= 127 and 0 <= slot <= 1023 and -24 - 25i0 + slot <= 128*floor((28 + slot)/128) <= -25i0 + slot and 128*floor((28 + slot)/128) <= slot and 5*floor((slot + 2*floor((28 + slot)/128))/5) >= 50i0 - 5i2 - slot + 258*floor((28 + slot)/128) and 5*floor((slot + 2*floor((28 + slot)/128))/5) <= 49 + 50i0 - 5i2 - slot + 258*floor((28 + slot)/128) }">
#layout3 = #tensor_ext.layout<"{ [i0, i1, i2, i3] -> [ct, slot] : i0 = 0 and ct = 0 and (-25i1 - 5i2 - i3 + slot) mod 128 = 0 and 0 <= i1 <= 3 and 0 <= i2 <= 4 and 0 <= i3 <= 4 and 0 <= slot <= 1023 }">
#layout4 = #tensor_ext.layout<"{ [i0, i1, i2, i3] -> [ct, slot] : i0 = 0 and ct = 0 and (-25i1 - 5i2 - i3 + slot) mod 128 = 0 and 0 <= i1 <= 3 and 0 <= i2 <= 4 and 0 <= i3 <= 1023 - 25i1 - 5i2 and i3 <= 4 and 0 <= slot <= 1023 and 1024*floor((-128 + 25i1 + 5i2 + i3)/1024) <= -1024 + 25i1 + 5i2 + i3 }">
#layout5 = #tensor_ext.layout<"{ [i0, i1, i2, i3] -> [ct, slot] : exists (e0, e1, e2, e3, e5: i1 = 0 and (28 + slot) mod 128 = 28 - i0 + 2e2 and 128e5 = -10i2 - i3 + ct + slot - 20e0 - 2e1 and 0 <= i0 <= 3 and 0 <= i2 <= 1 and 0 <= i3 <= 1 and 0 <= ct <= 127 and 0 <= slot <= 1023 and 0 <= e0 <= 4 and 0 <= e1 <= 4 and i0 <= 2e2 <= 99 + i0 and -1 + i0 + 4e0 <= 2e3 <= i0 + 4e0 and -1 - i0 - 2e1 + 2e2 <= 10e3 <= -i0 - 2e1 + 2e2) }">
#layout6 = #tensor_ext.layout<"{ [i0, i1, i2, i3] -> [ct, slot] : exists (e1, e2, e3: i0 = 0 and ct = 0 and 0 <= i1 <= 3 and 0 <= i2 <= 4 and 0 <= i3 <= 4 and 0 <= slot <= 1023 and 128*floor((-1 - 25i1 - 5i2 - i3)/128) <= -29 - 25i1 - 5i2 - i3 and 0 <= e1 <= 4 and 128*floor((28 + slot)/128) >= slot - 2e2 and slot - 4e1 - 2e2 + 2e3 <= 128*floor((28 + slot)/128) <= 1 + slot - 4e1 - 2e2 + 2e3 and 128*floor((28 + slot)/128) <= 3 + slot - 2e2 and 128*floor((28 + slot)/128) <= slot and 124 + 25i1 + 5i2 + i3 + 25slot + 128*floor((-1 - 25i1 - 5i2 - i3)/128) - 5e1 - 50e2 <= 3200*floor((28 + slot)/128) <= 128 + 25i1 + 5i2 + i3 + 25slot + 128*floor((-1 - 25i1 - 5i2 - i3)/128) - 5e1 - 50e2 and 256 + 50i1 + 10i2 + 2i3 + 49slot + 256*floor((-1 - 25i1 - 5i2 - i3)/128) - 10e1 - 100e2 + 10e3 <= 6272*floor((28 + slot)/128) <= 257 + 50i1 + 10i2 + 2i3 + 49slot + 256*floor((-1 - 25i1 - 5i2 - i3)/128) - 10e1 - 100e2 + 10e3) }">
#layout7 = #tensor_ext.layout<"{ [i0, i1, i2, i3] -> [ct, slot] : exists (e0, e1, e2: i1 = 0 and 16384e2 = -2500i0 - 10i2 - i3 + 1024ct + slot - 520e0 - 102e1 and 0 <= i0 <= 3 and 0 <= i2 <= 1 and 0 <= i3 <= 1 and 0 <= ct <= 9 and 0 <= slot <= 1023 and 0 <= e0 <= 4 and 0 <= e1 <= 4 and -1250i0 - 5i2 + 512ct - 260e0 <= 51e1 <= 511 - 1250i0 - 5i2 + 512ct - 260e0) }">
module {
  func.func @conv2d(%arg0: tensor<1x1x10x10xf32>, %arg1: tensor<4x1x2x2xf32>) -> tensor<1x4x5x5xf32> {
    %0 = tensor.empty() : tensor<1x4x5x5xf32>
    
    %1 = tensor_ext.convert_layout %arg0 {from_layout = #layout, tensor_ext.layout = #layout, to_layout = #layout} : tensor<1x1x10x10xf32>
    %2 = tensor_ext.convert_layout %arg1 {domainSchedule = array<i64: 0, 1>, from_layout = #layout1, tensor_ext.layout = #layout2, to_layout = #layout2} : tensor<4x1x2x2xf32>
    %3 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, secret.kernel = #kernel, strides = dense<2> : vector<2xi64>, tensor_ext.layout = #layout3} ins(%1, %2 : tensor<1x1x10x10xf32>, tensor<4x1x2x2xf32>) outs(%0 : tensor<1x4x5x5xf32>) -> tensor<1x4x5x5xf32>
    %4 = tensor_ext.convert_layout %3 {from_layout = #layout3, tensor_ext.layout = #layout4, to_layout = #layout4} : tensor<1x4x5x5xf32>
    
    %5 = tensor_ext.convert_layout %arg0 {from_layout = #layout, tensor_ext.layout = #layout, to_layout = #layout} : tensor<1x1x10x10xf32>
    %6 = tensor_ext.convert_layout %arg1 {domainSchedule = array<i64: 0, 1>, from_layout = #layout1, tensor_ext.layout = #layout5, to_layout = #layout5} : tensor<4x1x2x2xf32>
    %7 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, secret.kernel = #kernel, strides = dense<2> : vector<2xi64>, tensor_ext.layout = #layout6} ins(%5, %6 : tensor<1x1x10x10xf32>, tensor<4x1x2x2xf32>) outs(%0 : tensor<1x4x5x5xf32>) -> tensor<1x4x5x5xf32>
    %8 = tensor_ext.convert_layout %7 {from_layout = #layout6, tensor_ext.layout = #layout4, to_layout = #layout4} : tensor<1x4x5x5xf32>
    
    %9 = tensor_ext.convert_layout %arg0 {from_layout = #layout, tensor_ext.layout = #layout, to_layout = #layout} : tensor<1x1x10x10xf32>
    %10 = tensor_ext.convert_layout %arg1 {from_layout = #layout1, tensor_ext.layout = #layout7, to_layout = #layout7} : tensor<4x1x2x2xf32>
    %11 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, secret.kernel = #kernel1, strides = dense<2> : vector<2xi64>, tensor_ext.layout = #layout4} ins(%9, %10 : tensor<1x1x10x10xf32>, tensor<4x1x2x2xf32>) outs(%0 : tensor<1x4x5x5xf32>) -> tensor<1x4x5x5xf32>
    %12 = tensor_ext.convert_layout %11 {from_layout = #layout4, tensor_ext.layout = #layout4, to_layout = #layout4} : tensor<1x4x5x5xf32>
    
    %13 = linalg.conv_2d_nchw_fchw {dilations = dense<1> : vector<2xi64>, strides = dense<2> : vector<2xi64>} ins(%arg0, %arg1 : tensor<1x1x10x10xf32>, tensor<4x1x2x2xf32>) outs(%0 : tensor<1x4x5x5xf32>) -> tensor<1x4x5x5xf32>
    
    %14 = equivalence.class %4, %8, %12, %13 : tensor<1x4x5x5xf32>
    return %14 : tensor<1x4x5x5xf32>
  }
}
```

I added `MatvecNaive` as a layout even though it seems that this cannot be fully lowered yet (?).

Note I haven't yet hooked this up to a full equality saturation flow. My current thinking is that it makes sense to hold off on running equality saturation as long as possible (if it even makes sense ever in the compilation flow)? For now, building blocks such as these can be developed; should equality saturation be useful in the future, this code can be used there as well.

All of this is meant to get a better feeling of the codebase, not necessarily to be merged anywhere yet. If things turn out to be useful to have, I can split them off in proper PRs.
Next step would be to go down the compilation flow and see how long these equivalences can be kept around?